### PR TITLE
feat(core): add support for community remote caching

### DIFF
--- a/packages/nx/src/adapter/compat.ts
+++ b/packages/nx/src/adapter/compat.ts
@@ -81,6 +81,7 @@ export const allowedWorkspaceExtensions = [
   'neverConnectToCloud',
   'sync',
   'useLegacyCache',
+  'remoteCache',
 ] as const;
 
 if (!patched) {

--- a/packages/nx/src/config/nx-json.ts
+++ b/packages/nx/src/config/nx-json.ts
@@ -520,6 +520,11 @@ export interface NxJsonConfiguration<T = '*' | string[]> {
    * Use the legacy file system cache instead of the db cache
    */
   useLegacyCache?: boolean;
+
+  /**
+   * community support for custom cache
+   */
+  remoteCache?: string;
 }
 
 export type PluginConfiguration = string | ExpandedPluginConfiguration;

--- a/packages/nx/src/tasks-runner/cache.ts
+++ b/packages/nx/src/tasks-runner/cache.ts
@@ -156,6 +156,7 @@ export class DbCache {
       }
     } else {
       return (
+        (await this.getCustomCache(nxJson.remoteCache)) ??
         (await this.getPowerpackS3Cache()) ??
         (await this.getPowerpackSharedCache()) ??
         null
@@ -164,14 +165,14 @@ export class DbCache {
   }
 
   private getPowerpackS3Cache(): Promise<RemoteCacheV2 | null> {
-    return this.getPowerpackCache('@nx/powerpack-s3-cache');
+    return this.getCustomCache('@nx/powerpack-s3-cache');
   }
 
   private getPowerpackSharedCache(): Promise<RemoteCacheV2 | null> {
-    return this.getPowerpackCache('@nx/powerpack-shared-fs-cache');
+    return this.getCustomCache('@nx/powerpack-shared-fs-cache');
   }
 
-  private async getPowerpackCache(pkg: string): Promise<RemoteCacheV2 | null> {
+  private async getCustomCache(pkg: string): Promise<RemoteCacheV2 | null> {
     let getRemoteCache = null;
     try {
       getRemoteCache = (await import(this.resolvePackage(pkg))).getRemoteCache;


### PR DESCRIPTION
It is with great sadness that this PR has come to light as a soft fork of NX.

This is in response to the following:
https://github.com/NiklasPor/nx-remotecache-custom/issues/48
https://github.com/nrwl/nx/issues/28434
https://github.com/nrwl/nx/issues/28150

This introduces a new `nx.json` configuration property called `remoteCache`, which will allow independent developers to implement custom remote caching more easily without losing any of NX's functionality. In the long term, this should be supported within NX, and hopefully, this will eventually happen. In the meantime, this also aims to support the pure Rust version of NX as well.

Please, NX, reconsider making it Powerpack-only. Even making it temporarily Powerpack-only is not a good idea.